### PR TITLE
A device should be able to use it's local queue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,14 @@ impl SonosDevice {
         .await
     }
 
+    /// Tells a device to use its own local queue.
+    /// This is useful for example when a device first powers on and doesn't yet
+    /// have a proper transport uri that can be used for queuing tracks.
+    pub async fn set_queue_to_self(&self) -> Result<()> {
+        self.set_av_transport_uri(&format!("x-rincon-queue:{}#0", self.uuid().await?), None)
+            .await
+    }
+
     pub async fn queue_prepend(
         &self,
         uri: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ pub enum Error {
     LastChangeFormatUnexpected(String),
     #[error("Device reports None for volume")]
     VolumeNone,
+    #[error("Device missing from zone groups")]
+    ZoneGroupMemberMissing,
 }
 
 impl Error {
@@ -331,6 +333,19 @@ impl SonosDevice {
 
     pub fn url(&self) -> &Url {
         &self.url
+    }
+
+    // Returns the uuid of a device
+    pub async fn uuid(&self) -> Result<String> {
+        let uuid = self
+            .get_zone_group_state()
+            .await?
+            .into_iter()
+            .flat_map(|zone_group| zone_group.members)
+            .find(|member| member.location == self.url.as_str())
+            .map(|member| member.uuid);
+
+        uuid.ok_or(Error::ZoneGroupMemberMissing)
     }
 }
 


### PR DESCRIPTION
This PR allows you to tell a device to play from its own local queue.

When a device has freshly powered on and you attempt to queue a track you will get an error with code 701.
I did some digging with Wireshark to see what the macOS app does when you attempt to queue a track and found that it issues a AVTransport command with a uri of `x-rincon-queue:RINCON_XXXXXXXXXXXX0#0` followed by the track queue command.

